### PR TITLE
bugfix: addSliceToUrl pass index rather than name

### DIFF
--- a/app/public/js/microdraw.js
+++ b/app/public/js/microdraw.js
@@ -1875,8 +1875,9 @@ const Microdraw = (function () {
 
         if(me.params.slice === "undefined" || typeof me.params.slice === "undefined") { // this is correct: the string "undefined", or the type
           me.initSlider(0, obj.tileSources.length, 1, Math.round(obj.tileSources.length / 2));
-          me.currentImage = me.imageOrder[Math.floor(obj.tileSources.length / 2)];
-          me.addSliceToURL(me.currentImage);
+          const newIndex = Math.floor(obj.tileSources.length / 2)
+          me.currentImage = me.imageOrder[newIndex];
+          me.addSliceToURL(newIndex);
         } else {
           me.initSlider(0, obj.tileSources.length, 1, me.params.slice);
           me.currentImage = me.imageOrder[[parseInt(me.params.slice, 10)]];


### PR DESCRIPTION
When testing the prod version of microdraw, we noticed that `Microdraw.addSliceToURL` actually expects an index, but might be passed `Microdraw.imageOrder[index]` instead. 

thanks to @pacher for reporting the issue

<!-- Thank you so much for your contribution to MicroDraw! <3 -->

<!-- Please find a short title for your pull request and describe your changes on the following line: -->

<!-- Please run our tests -->
- [x] Run `npm test` successfully. 
- [x] Run `npm run mocha`successfully.

- [x] `test_screenshots` generates the same test pictures in `test` as there were in `test/reference` and does not show any errors

<!-- Either: -->
- [ ] I implemented tests for the new changes OR
- [x] These changes do not require tests because minor bug fix

- [ ] These changes fix #__ (github issue number if applicable).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Again, many many thanks for your work! \ö/ -->

