### PR TITLE
Fix the 'save' end-to-end test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ test/*.png
 access.log
 package-lock.json
 app/controller/api/tmp
-test/e2e/screenshots/
+test/e2e/screenshots/*.png
 .gitignore
 cert.pem
 cfg.json

--- a/test/e2e/save.spec.js
+++ b/test/e2e/save.spec.js
@@ -3,7 +3,24 @@ const assert = require('assert');
 const mongoDbPath = process.env.MONGODB_TEST;
 if (!mongoDbPath) { throw new Error(`MONGODB_TEST must be explicitly set to avoid overwriting production `); }
 
-const db = require('../../app/db/db')(mongoDbPath);
+const mockedExpress = {
+  use: () => {},
+  get: () => {},
+  post: () => {},
+  set: () => {}
+};
+const path = require('path');
+const nwl = require('neuroweblab');
+nwl.init({
+  app: mockedExpress,
+  dirname: path.join(__dirname, "/auth/"),
+  MONGO_DB: process.env.MONGODB_TEST,
+  usernameField: "username",
+  usersCollection: "users",
+  projectsCollection: "projects",
+  annotationsCollection: "annotations"
+});
+const {db} = mockedExpress;
 
 describe('mocha works', () => {
   it('mocha works', () => {
@@ -13,7 +30,7 @@ describe('mocha works', () => {
 
 describe('annotation saved by puppeteer can be retrieved', () => {
   after(() => {
-    db.db.close();
+    db.mongoDB().close();
   });
   it('works', (done) => {
     db.findAnnotations({


### PR DESCRIPTION
Fix the "save" end to end test that was failing.

I added the `test/e2e/screenshots` folder to git and edited the `.gitignore` file to just ignore the images inside. My tests were failing because the folder was missing.

I don't think one should have to mock express if willing to just use the "db" service from the neuroweblab package.
It seems to me that such coupling could be prejudicial. I may suggest a change related to this later on.
