### PR TITLE
avoid waiting to be blocked by cors when loading a dataset in localhost

### DIFF
--- a/app/public/js/microdraw.js
+++ b/app/public/js/microdraw.js
@@ -1628,6 +1628,10 @@ const Microdraw = (function () {
 
       return new Promise((resolve, reject) => {
         const directFetch = new Promise((rs, rj) => {
+          // determine if request will be blocked by CORS policy
+          if ((new URL(me.params.source)).origin !== me.params.source.origin) {
+            rj(new Error('request origin do not match page origin'));
+          }
           // decide between json (local) and jsonp (cross-origin)
           let ext = me.params.source.split(".");
           ext = ext[ext.length - 1];


### PR DESCRIPTION
When we load a dataset in localhost, microdraw first tries to load the JSON from the app, which takes some time, and then after the fail it tries to download from the server. The app request is blocked by CORS so it is useless to wait, and in case it would not we could get an error as the json has to be modified by the server for a cross domain request.
By downloading directly we get:
```
{
  "pixelsPerMeter": 1000000, 
  "tileSources": [
    "vervet/vervet.dzi"
  ]
}
```
By downloading with the server we get:
```
{
  "pixelsPerMeter": 1000000, 
  "tileSources": [
    "http://localhost:3000/getTile?source=https://microdraw.pasteur.fr/vervet/vervet.dzi"
  ]
}
```
Only the second will work when in localhost, as the dzi is not part of the local version.